### PR TITLE
V10.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Chat that helps teams stay productive and focused
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://zulip.com/)
-[![Version: 10.3~ynh1](https://img.shields.io/badge/Version-10.3~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/zulip/)
+[![Version: 10.4~ynh1](https://img.shields.io/badge/Version-10.4~ynh1-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/zulip/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/zulip"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Zulip"
 description.en = "Chat that helps teams stay productive and focused"
 description.fr = "Chat qui aide les équipes à rester productives et concentrées"
 
-version = "10.3~ynh1"
+version = "10.4~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -44,8 +44,8 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://github.com/zulip/zulip/releases/download/10.3/zulip-server-10.3.tar.gz"
-        sha256 = "71e8239a92f42587aa7e2b4b1092e0b9359c74edc17df8a2de00b6b43482560c"
+        url = "https://github.com/zulip/zulip/releases/download/10.3/zulip-server-10.4.tar.gz"
+        sha256 = "dfce2d7834023572f27acf49f824e137fef1390ed79a368c387dc293e265dbff"
         autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]

--- a/manifest.toml
+++ b/manifest.toml
@@ -44,7 +44,7 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://github.com/zulip/zulip/releases/download/10.3/zulip-server-10.4.tar.gz"
+        url = "https://github.com/zulip/zulip/releases/download/10.4/zulip-server-10.4.tar.gz"
         sha256 = "dfce2d7834023572f27acf49f824e137fef1390ed79a368c387dc293e265dbff"
         autoupdate.strategy = "latest_github_tag"
 


### PR DESCRIPTION
CVE-2025-52559 fixed in v10.4
https://zulip.readthedocs.io/en/latest/overview/changelog.html#zulip-server-10-4
https://security-tracker.debian.org/tracker/CVE-2025-52559
